### PR TITLE
Reduce grammar ambiguities

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 // ANTLR configuration
 generateGrammarSource {
     arguments += [
+        // Generate state transition graphs
+        "-atn",
         // Needed to make gradle aware of grammar imports.
         "-lib", "src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar",
         "-package", "com.lucaskjaerozhang.wikitext_parser.grammar",

--- a/lib/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/WikiText.g4
+++ b/lib/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/WikiText.g4
@@ -130,13 +130,19 @@ italics
    ;
 
 xmlTag
-   : OPEN_CARAT SPACE* text tagAttribute* CLOSE_CARAT sectionContent+ OPEN_CARAT SLASH text CLOSE_CARAT # ContainerXMLTag
-   | OPEN_CARAT SPACE* text tagAttribute* SLASH CLOSE_CARAT # StandaloneXMLTag
+   : OPEN_CARAT textWithoutSpaces tagAttribute* SPACE* CLOSE_CARAT sectionContent+ OPEN_CARAT SLASH textWithoutSpaces CLOSE_CARAT # ContainerXMLTag
+   | OPEN_CARAT textWithoutSpaces tagAttribute* SPACE* SLASH CLOSE_CARAT # StandaloneXMLTag
    ;
 
 tagAttribute
-   : SPACE* text EQUALS SINGLE_QUOTE tagAttributeValues+ SINGLE_QUOTE SPACE* # SingleQuoteTagAttribute
-   | SPACE* text EQUALS DOUBLE_QUOTE tagAttributeValues+ DOUBLE_QUOTE SPACE* # DoubleQuoteTagAttribute
+   : SPACE* tagAttributeKeyValues EQUALS SINGLE_QUOTE tagAttributeValues+ SINGLE_QUOTE # SingleQuoteTagAttribute
+   | SPACE* tagAttributeKeyValues EQUALS DOUBLE_QUOTE tagAttributeValues+ DOUBLE_QUOTE # DoubleQuoteTagAttribute
+   ;
+
+tagAttributeKeyValues
+   : textWithoutSpaces
+   | COLON
+   | SEMICOLON
    ;
 
 tagAttributeValues
@@ -220,6 +226,16 @@ text
 textUnion
    : TEXT
    | SPACE
+   | DASH
+   | CHARACTER_REFERENCE
+   ;
+
+textWithoutSpaces
+   : textUnionNoSpaces+
+   ;
+
+textUnionNoSpaces
+   : TEXT
    | DASH
    | CHARACTER_REFERENCE
    ;

--- a/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/Parser.java
+++ b/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/Parser.java
@@ -15,4 +15,8 @@ public class Parser {
   public static String parseToString(String inputText) {
     return writeToString(parse(inputText));
   }
+
+  private Parser() {
+    throw new IllegalStateException("Utility class");
+  }
 }

--- a/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/parse/SetupParse.java
+++ b/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/parse/SetupParse.java
@@ -3,15 +3,16 @@ package com.lucaskjaerozhang.wikitext_parser.parse;
 import com.lucaskjaerozhang.wikitext_parser.ast.base.WikiTextElement;
 import com.lucaskjaerozhang.wikitext_parser.grammar.WikiTextLexer;
 import com.lucaskjaerozhang.wikitext_parser.grammar.WikiTextParser;
+import java.util.List;
 import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 
 /** Here we invoke antlr to build the parse tree. */
 public class SetupParse {
-  public static WikiTextLexer getLexerFromText(String text, ANTLRErrorListener listener) {
+  public static WikiTextLexer getLexerFromText(String text, List<ANTLRErrorListener> listeners) {
     WikiTextLexer lexer = new WikiTextLexer(CharStreams.fromString(text));
-    lexer.addErrorListener(listener);
+    listeners.forEach(lexer::addErrorListener);
     return lexer;
   }
 
@@ -19,22 +20,22 @@ public class SetupParse {
    * Builds the parse tree
    *
    * @param text The text to parse
-   * @param listener An error listener to react to parse problems
+   * @param listeners A set of error listeners to react to parse problems
    * @return The parse tree.
    */
-  public static WikiTextParser getParserFromText(String text, ANTLRErrorListener listener) {
+  public static WikiTextParser getParserFromText(String text, List<ANTLRErrorListener> listeners) {
     WikiTextParser parser =
-        new WikiTextParser(new CommonTokenStream(getLexerFromText(text, listener)));
-    parser.addErrorListener(listener);
+        new WikiTextParser(new CommonTokenStream(getLexerFromText(text, listeners)));
+    listeners.forEach(parser::addErrorListener);
     return parser;
   }
 
-  public static WikiTextElement visitTreeFromText(String text, ANTLRErrorListener listener) {
-    return new WikitextVisitor().visit(getParserFromText(text, listener).root());
+  public static WikiTextElement visitTreeFromText(String text, List<ANTLRErrorListener> listeners) {
+    return new WikitextVisitor().visit(getParserFromText(text, listeners).root());
   }
 
   public static WikiTextElement visitTreeFromText(String text) {
-    return visitTreeFromText(text, new WikiTextErrorListener());
+    return visitTreeFromText(text, List.of(new WikiTextErrorListener()));
   }
 
   private SetupParse() {

--- a/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/parse/SetupParse.java
+++ b/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/parse/SetupParse.java
@@ -21,21 +21,47 @@ public class SetupParse {
    *
    * @param text The text to parse
    * @param listeners A set of error listeners to react to parse problems
+   * @param trace Whether to print trace logs
    * @return The parse tree.
    */
-  public static WikiTextParser getParserFromText(String text, List<ANTLRErrorListener> listeners) {
+  public static WikiTextParser getParserFromText(
+      String text, List<ANTLRErrorListener> listeners, boolean trace) {
     WikiTextParser parser =
         new WikiTextParser(new CommonTokenStream(getLexerFromText(text, listeners)));
+    parser.setTrace(trace);
     listeners.forEach(parser::addErrorListener);
     return parser;
   }
 
-  public static WikiTextElement visitTreeFromText(String text, List<ANTLRErrorListener> listeners) {
-    return new WikitextVisitor().visit(getParserFromText(text, listeners).root());
+  /**
+   * Does the parsing with the included error listeners and the option to enable trace logs.
+   *
+   * @param text The text to parse
+   * @return The AST built from the input.
+   */
+  public static WikiTextElement visitTreeFromText(
+      String text, List<ANTLRErrorListener> listeners, boolean trace) {
+    return new WikitextVisitor().visit(getParserFromText(text, listeners, trace).root());
   }
 
+  /**
+   * Does the parsing with the option to enable trace logs.
+   *
+   * @param text The text to parse
+   * @return The AST built from the input.
+   */
+  public static WikiTextElement visitTreeFromText(String text, boolean trace) {
+    return visitTreeFromText(text, List.of(new WikiTextErrorListener()), trace);
+  }
+
+  /**
+   * Does the parsing with default settings.
+   *
+   * @param text The text to parse
+   * @return The AST built from the input.
+   */
   public static WikiTextElement visitTreeFromText(String text) {
-    return visitTreeFromText(text, List.of(new WikiTextErrorListener()));
+    return visitTreeFromText(text, false);
   }
 
   private SetupParse() {

--- a/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/parse/WikitextVisitor.java
+++ b/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/parse/WikitextVisitor.java
@@ -107,7 +107,7 @@ public class WikitextVisitor extends WikiTextBaseVisitor<WikiTextElement> {
 
   @Override
   public XMLContainerElement visitContainerXMLTag(WikiTextParser.ContainerXMLTagContext ctx) {
-    String tag = ctx.text(0).getText();
+    String tag = ctx.textWithoutSpaces(0).getText();
     List<NodeAttribute> attributes =
         ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
     List<WikiTextNode> content =
@@ -118,7 +118,7 @@ public class WikitextVisitor extends WikiTextBaseVisitor<WikiTextElement> {
 
   @Override
   public XMLStandaloneElement visitStandaloneXMLTag(WikiTextParser.StandaloneXMLTagContext ctx) {
-    String tag = ctx.text().getText();
+    String tag = ctx.textWithoutSpaces().getText();
     List<NodeAttribute> attributes =
         ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
 
@@ -190,7 +190,7 @@ public class WikitextVisitor extends WikiTextBaseVisitor<WikiTextElement> {
   @Override
   public NodeAttribute visitSingleQuoteTagAttribute(
       WikiTextParser.SingleQuoteTagAttributeContext ctx) {
-    String key = ctx.text().getText();
+    String key = ctx.tagAttributeKeyValues().getText();
     String value =
         ctx.tagAttributeValues().stream()
             .map(v -> (Text) visit(v))
@@ -202,7 +202,7 @@ public class WikitextVisitor extends WikiTextBaseVisitor<WikiTextElement> {
   @Override
   public NodeAttribute visitDoubleQuoteTagAttribute(
       WikiTextParser.DoubleQuoteTagAttributeContext ctx) {
-    String key = ctx.text().getText();
+    String key = ctx.tagAttributeKeyValues().getText();
     String value =
         ctx.tagAttributeValues().stream()
             .map(v -> (Text) visit(v))

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/TestErrorListener.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/TestErrorListener.java
@@ -1,16 +1,13 @@
 package com.lucaskjaerozhang.wikitext_parser.grammar;
 
 import java.util.BitSet;
-import org.antlr.v4.runtime.DiagnosticErrorListener;
-import org.antlr.v4.runtime.Parser;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.junit.jupiter.api.Assertions;
 
 /** We mostly want errors from DiagnosticErrorListener, but want to customize it a bit.. */
-public class TestErrorListener extends DiagnosticErrorListener {
+public class TestErrorListener /*extends DiagnosticErrorListener*/ implements ANTLRErrorListener {
 
   @Override
   public void syntaxError(
@@ -21,6 +18,18 @@ public class TestErrorListener extends DiagnosticErrorListener {
       String msg,
       RecognitionException e) {
     Assertions.fail(msg, e);
+  }
+
+  @Override
+  public void reportAmbiguity(
+      Parser recognizer,
+      DFA dfa,
+      int startIndex,
+      int stopIndex,
+      boolean exact,
+      BitSet ambigAlts,
+      ATNConfigSet configs) {
+    /* One error at a time. */
   }
 
   @Override

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/TestErrorListener.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/TestErrorListener.java
@@ -24,6 +24,17 @@ public class TestErrorListener extends DiagnosticErrorListener {
   }
 
   @Override
+  public void reportContextSensitivity(
+      Parser recognizer,
+      DFA dfa,
+      int startIndex,
+      int stopIndex,
+      int prediction,
+      ATNConfigSet configs) {
+    /* One error at a time. */
+  }
+
+  @Override
   public void reportAttemptingFullContext(
       Parser recognizer,
       DFA dfa,

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/TestErrorListener.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/TestErrorListener.java
@@ -1,7 +1,7 @@
 package com.lucaskjaerozhang.wikitext_parser.grammar;
 
 import java.util.BitSet;
-import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.DiagnosticErrorListener;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
@@ -9,7 +9,9 @@ import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.junit.jupiter.api.Assertions;
 
-public class TestErrorListener implements ANTLRErrorListener {
+/** We mostly want errors from DiagnosticErrorListener, but want to customize it a bit.. */
+public class TestErrorListener extends DiagnosticErrorListener {
+
   @Override
   public void syntaxError(
       Recognizer<?, ?> recognizer,
@@ -22,30 +24,16 @@ public class TestErrorListener implements ANTLRErrorListener {
   }
 
   @Override
-  public void reportAmbiguity(
-      Parser recognizer,
-      DFA dfa,
-      int startIndex,
-      int stopIndex,
-      boolean exact,
-      BitSet ambigAlts,
-      ATNConfigSet configs) {}
-
-  @Override
   public void reportAttemptingFullContext(
       Parser recognizer,
       DFA dfa,
       int startIndex,
       int stopIndex,
       BitSet conflictingAlts,
-      ATNConfigSet configs) {}
-
-  @Override
-  public void reportContextSensitivity(
-      Parser recognizer,
-      DFA dfa,
-      int startIndex,
-      int stopIndex,
-      int prediction,
-      ATNConfigSet configs) {}
+      ATNConfigSet configs) {
+    /*
+    Intentionally suppressing this for now as it indicates inefficiency, not actual ambiguity.
+    I will optimize the grammar when it's fully written, but for now it's premature.
+    */
+  }
 }

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/WikitextGrammarBaseTest.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/WikitextGrammarBaseTest.java
@@ -4,6 +4,7 @@ import com.lucaskjaerozhang.wikitext_parser.parse.SetupParse;
 import java.util.Collection;
 import java.util.List;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.DiagnosticErrorListener;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.xpath.XPath;
@@ -68,7 +69,8 @@ public class WikitextGrammarBaseTest {
    * @return A new lexer from the test string.
    */
   protected WikiTextLexer getLexerFromString(String testString) {
-    return SetupParse.getLexerFromText(testString, new TestErrorListener());
+    return SetupParse.getLexerFromText(
+        testString, List.of(new DiagnosticErrorListener(), new TestErrorListener()));
   }
 
   /**
@@ -78,7 +80,8 @@ public class WikitextGrammarBaseTest {
    * @return A new parser.
    */
   protected WikiTextParser getParserFromString(String testString) {
-    return SetupParse.getParserFromText(testString, new TestErrorListener());
+    return SetupParse.getParserFromText(
+        testString, List.of(new DiagnosticErrorListener(), new TestErrorListener()));
   }
 
   /**

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/WikitextGrammarBaseTest.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/WikitextGrammarBaseTest.java
@@ -82,7 +82,7 @@ public class WikitextGrammarBaseTest {
    */
   protected WikiTextParser getParserFromString(String testString) {
     WikiTextParser parser =
-        SetupParse.getParserFromText(testString, List.of(new TestErrorListener()));
+        SetupParse.getParserFromText(testString, List.of(new TestErrorListener()), true);
     // Really dig in deep to find ambiguities.
     parser.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
     return parser;

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/WikitextGrammarBaseTest.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/WikitextGrammarBaseTest.java
@@ -82,8 +82,7 @@ public class WikitextGrammarBaseTest {
    */
   protected WikiTextParser getParserFromString(String testString) {
     WikiTextParser parser =
-        SetupParse.getParserFromText(
-            testString, List.of(new DiagnosticErrorListener(), new TestErrorListener()));
+        SetupParse.getParserFromText(testString, List.of(new TestErrorListener()));
     // Really dig in deep to find ambiguities.
     parser.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
     return parser;

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/WikitextGrammarBaseTest.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/WikitextGrammarBaseTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.DiagnosticErrorListener;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.xpath.XPath;
 import org.junit.jupiter.api.Assertions;
@@ -80,8 +81,12 @@ public class WikitextGrammarBaseTest {
    * @return A new parser.
    */
   protected WikiTextParser getParserFromString(String testString) {
-    return SetupParse.getParserFromText(
-        testString, List.of(new DiagnosticErrorListener(), new TestErrorListener()));
+    WikiTextParser parser =
+        SetupParse.getParserFromText(
+            testString, List.of(new DiagnosticErrorListener(), new TestErrorListener()));
+    // Really dig in deep to find ambiguities.
+    parser.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
+    return parser;
   }
 
   /**

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/layout/LayoutGrammarTest.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/layout/LayoutGrammarTest.java
@@ -97,7 +97,7 @@ class LayoutGrammarTest extends WikitextGrammarBaseTest {
 
     testParseTreeString(
         stringWithBlockQuote,
-        "(root (baseElements (sectionContent (xmlTag < (text (textUnion blockquote)) > (sectionContent (text (textUnion Some) (textUnion  ) (textUnion text))) (sectionContent \\n\\n) (sectionContent (text (textUnion More) (textUnion  ) (textUnion text))) < / (text (textUnion blockquote)) >))))");
+        "(root (baseElements (sectionContent (xmlTag < (textWithoutSpaces (textUnionNoSpaces blockquote)) > (sectionContent (text (textUnion Some) (textUnion  ) (textUnion text))) (sectionContent \\n\\n) (sectionContent (text (textUnion More) (textUnion  ) (textUnion text))) < / (textWithoutSpaces (textUnionNoSpaces blockquote)) >))))");
 
     Assertions.assertEquals(blockquoteXML, Parser.parseToString(stringWithBlockQuote));
   }
@@ -113,7 +113,7 @@ class LayoutGrammarTest extends WikitextGrammarBaseTest {
 
     testParseTreeString(
         stringWithPoem,
-        "(root (baseElements (sectionContent (xmlTag < (text (textUnion poem) (textUnion  )) (tagAttribute (text (textUnion lang)) = \" (tagAttributeValues (text (textUnion fr))) \"  ) (tagAttribute (text (textUnion style)) = \" (tagAttributeValues (text (textUnion float))) (tagAttributeValues :) (tagAttributeValues (text (textUnion left))) (tagAttributeValues ;) \") > (sectionContent (text (textUnion Frère) (textUnion  ) (textUnion Jacques,) (textUnion  ) (textUnion frère) (textUnion  ) (textUnion Jacques,))) (sectionContent \\n) (sectionContent (text (textUnion Dormez) (textUnion -) (textUnion vous?) (textUnion  ) (textUnion Dormez) (textUnion -) (textUnion vous?))) < / (text (textUnion poem)) >))))");
+        "(root (baseElements (sectionContent (xmlTag < (textWithoutSpaces (textUnionNoSpaces poem)) (tagAttribute   (tagAttributeKeyValues (textWithoutSpaces (textUnionNoSpaces lang))) = \" (tagAttributeValues (text (textUnion fr))) \") (tagAttribute   (tagAttributeKeyValues (textWithoutSpaces (textUnionNoSpaces style))) = \" (tagAttributeValues (text (textUnion float))) (tagAttributeValues :) (tagAttributeValues (text (textUnion left))) (tagAttributeValues ;) \") > (sectionContent (text (textUnion Frère) (textUnion  ) (textUnion Jacques,) (textUnion  ) (textUnion frère) (textUnion  ) (textUnion Jacques,))) (sectionContent \\n) (sectionContent (text (textUnion Dormez) (textUnion -) (textUnion vous?) (textUnion  ) (textUnion Dormez) (textUnion -) (textUnion vous?))) < / (textWithoutSpaces (textUnionNoSpaces poem)) >))))");
 
     Assertions.assertEquals(poemXML, Parser.parseToString(stringWithPoem));
   }


### PR DESCRIPTION
- Set up the test framework to be able to report grammar ambiguities.
- Remove an ambiguity in xml tags.
- Set grammar tracing in tests so it's easy to see what went wrong.
- Generate state machine diagrams for debugging.