### PR TITLE
Case insensitive unparsed blocks

### DIFF
--- a/lib/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/WikiText.g4
+++ b/lib/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/WikiText.g4
@@ -105,19 +105,23 @@ sectionContentNoNewline
    ;
 
 codeBlock
-   : OPEN_CARAT SPACE* 'code' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'code' SPACE* CLOSE_CARAT
+   : OPEN_CARAT SPACE* 'code' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'code' SPACE* CLOSE_CARAT # LowercaseCodeBlock
+   | OPEN_CARAT SPACE* 'CODE' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'CODE' SPACE* CLOSE_CARAT # UppercaseCodeBlock
    ;
 
 syntaxHighlightBlock
-   : OPEN_CARAT SPACE* 'syntaxhighlight' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'syntaxhighlight' SPACE* CLOSE_CARAT
+   : OPEN_CARAT SPACE* 'syntaxhighlight' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'syntaxhighlight' SPACE* CLOSE_CARAT # LowercaseSyntaxHighlightBlock
+   | OPEN_CARAT SPACE* 'SYNTAXHIGHLIGHT' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'SYNTAXHIGHLIGHT' SPACE* CLOSE_CARAT # UppercaseSyntaxHighlightCodeBlock
    ;
 
 mathBlock
-   : OPEN_CARAT SPACE* 'math' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'math' SPACE* CLOSE_CARAT
+   : OPEN_CARAT SPACE* 'math' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'math' SPACE* CLOSE_CARAT # LowercaseMathBlock
+   | OPEN_CARAT SPACE* 'MATH' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'MATH' SPACE* CLOSE_CARAT # UppercaseMathBlock
    ;
 
 noWikiBlock
-   : OPEN_CARAT SPACE* 'nowiki' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'nowiki' SPACE* CLOSE_CARAT
+   : OPEN_CARAT SPACE* 'nowiki' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'nowiki' SPACE* CLOSE_CARAT # LowercaseNowikiBlock
+   | OPEN_CARAT SPACE* 'NOWIKI' tagAttribute* CLOSE_CARAT anySequence OPEN_CARAT SLASH SPACE* 'NOWIKI' SPACE* CLOSE_CARAT # UppercaseNowikiBlock
    ;
 
 template

--- a/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/parse/WikitextVisitor.java
+++ b/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/parse/WikitextVisitor.java
@@ -136,8 +136,7 @@ public class WikitextVisitor extends WikiTextBaseVisitor<WikiTextElement> {
    * Instead we short circuit parsing early.
    */
   @Override
-  public XMLContainerElement visitCodeBlock(WikiTextParser.CodeBlockContext ctx) {
-    // TODO make this case insensitive
+  public WikiTextElement visitLowercaseCodeBlock(WikiTextParser.LowercaseCodeBlockContext ctx) {
     String tag = "code";
     List<NodeAttribute> attributes =
         ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
@@ -152,10 +151,40 @@ public class WikitextVisitor extends WikiTextBaseVisitor<WikiTextElement> {
    * Instead we short circuit parsing early.
    */
   @Override
-  public XMLContainerElement visitSyntaxHighlightBlock(
-      WikiTextParser.SyntaxHighlightBlockContext ctx) {
-    // TODO make this case insensitive
+  public WikiTextElement visitUppercaseCodeBlock(WikiTextParser.UppercaseCodeBlockContext ctx) {
+    String tag = "CODE";
+    List<NodeAttribute> attributes =
+        ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
+    String text = ctx.anySequence().getText();
+
+    return new XMLContainerElement(tag, attributes, List.of(new Text(text)));
+  }
+
+  /*
+   * This is a special case of xml tag basically.
+   * We don't want to parse the inside of the tag because it could be literally anything.
+   * Instead we short circuit parsing early.
+   */
+  @Override
+  public WikiTextElement visitLowercaseSyntaxHighlightBlock(
+      WikiTextParser.LowercaseSyntaxHighlightBlockContext ctx) {
     String tag = "syntaxhighlight";
+    List<NodeAttribute> attributes =
+        ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
+    String text = ctx.anySequence().getText();
+
+    return new XMLContainerElement(tag, attributes, List.of(new Text(text)));
+  }
+
+  /*
+   * This is a special case of xml tag basically.
+   * We don't want to parse the inside of the tag because it could be literally anything.
+   * Instead we short circuit parsing early.
+   */
+  @Override
+  public WikiTextElement visitUppercaseSyntaxHighlightCodeBlock(
+      WikiTextParser.UppercaseSyntaxHighlightCodeBlockContext ctx) {
+    String tag = "SYNTAXHIGHLIGHT";
     List<NodeAttribute> attributes =
         ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
     String text = ctx.anySequence().getText();
@@ -168,9 +197,22 @@ public class WikitextVisitor extends WikiTextBaseVisitor<WikiTextElement> {
    * We don't want to parse the inside of the tag because it is latex.
    */
   @Override
-  public XMLContainerElement visitMathBlock(WikiTextParser.MathBlockContext ctx) {
-    // TODO make this case insensitive
+  public WikiTextElement visitLowercaseMathBlock(WikiTextParser.LowercaseMathBlockContext ctx) {
     String tag = "math";
+    List<NodeAttribute> attributes =
+        ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
+    String text = ctx.anySequence().getText();
+
+    return new XMLContainerElement(tag, attributes, List.of(new Text(text)));
+  }
+
+  /*
+   * This is a special case of xml tag basically.
+   * We don't want to parse the inside of the tag because it is latex.
+   */
+  @Override
+  public WikiTextElement visitUppercaseMathBlock(WikiTextParser.UppercaseMathBlockContext ctx) {
+    String tag = "MATH";
     List<NodeAttribute> attributes =
         ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
     String text = ctx.anySequence().getText();
@@ -182,9 +224,21 @@ public class WikitextVisitor extends WikiTextBaseVisitor<WikiTextElement> {
    * <nowiki> blocks are where wikitext interpretation is explicitly turned off.
    */
   @Override
-  public XMLContainerElement visitNoWikiBlock(WikiTextParser.NoWikiBlockContext ctx) {
-    // TODO make this case insensitive
+  public WikiTextElement visitLowercaseNowikiBlock(WikiTextParser.LowercaseNowikiBlockContext ctx) {
     String tag = "nowiki";
+    List<NodeAttribute> attributes =
+        ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
+    String text = ctx.anySequence().getText();
+
+    return new XMLContainerElement(tag, attributes, List.of(new Text(text)));
+  }
+
+  /*
+   * <nowiki> blocks are where wikitext interpretation is explicitly turned off.
+   */
+  @Override
+  public WikiTextElement visitUppercaseNowikiBlock(WikiTextParser.UppercaseNowikiBlockContext ctx) {
+    String tag = "NOWIKI";
     List<NodeAttribute> attributes =
         ctx.tagAttribute().stream().map(c -> (NodeAttribute) visit(c)).toList();
     String text = ctx.anySequence().getText();

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/FormatGrammarTest.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/FormatGrammarTest.java
@@ -76,25 +76,42 @@ class FormatGrammarTest extends WikitextBaseTest {
   }
 
   @Test
-  void syntaxHighlightingBlocksDoNotBreakParser() {
-    final String stringWithCode =
-        """
-                    <syntaxhighlight lang="cpp">
-                    #include <iostream>
-                    int m2 (int ax, char *p_ax) {
-                      std::cout <<"Hello World!";
-                      return 0;
-                    }</syntaxhighlight>""";
-    final String codeXML =
-        """
-                    <article><syntaxhighlight lang="cpp">
-                    #include <iostream>
-                    int m2 (int ax, char *p_ax) {
-                    std::cout <<"Hello World!";
-                    return 0;
-                    }</syntaxhighlight></article>""";
+  void uppercaseCodeBlocksDoNotBreakParser() {
+    final String stringWithCode = "function <CODE>int m2()</CODE> is nice.\n";
+    final String codeXML = "<article>function <CODE>int m2()</CODE> is nice.\n</article>";
 
     testTranslation(stringWithCode, codeXML);
+  }
+
+  @Test
+  void syntaxHighlightingBlocksDoNotBreakParser() {
+    final String lowercaseTag = "syntaxhighlight";
+    final String uppercaseTag = "SYNTAXHIGHLIGHT";
+
+    final String stringWithCode =
+        """
+        <%s lang="cpp">
+        #include <iostream>
+        int m2 (int ax, char *p_ax) {
+          std::cout <<"Hello World!";
+          return 0;
+        }</%s>""";
+    final String codeXML =
+        """
+        <article><%s lang="cpp">
+        #include <iostream>
+        int m2 (int ax, char *p_ax) {
+        std::cout <<"Hello World!";
+        return 0;
+        }</%s></article>""";
+
+    testTranslation(
+        String.format(stringWithCode, lowercaseTag, lowercaseTag),
+        String.format(codeXML, lowercaseTag, lowercaseTag));
+
+    testTranslation(
+        String.format(stringWithCode, uppercaseTag, uppercaseTag),
+        String.format(codeXML, uppercaseTag, uppercaseTag));
   }
 
   @Test
@@ -108,11 +125,21 @@ class FormatGrammarTest extends WikitextBaseTest {
 
   @Test
   void mathBlocksDoNotBreakParser() {
-    final String stringWithCharacterReference =
+    final String stringWithMathBlock =
         "<math>2x \\times 4y \\div 6z + 8 - \\frac {y}{z^2} = 0</math>";
-    final String characterReferenceXML =
+    final String mathBlockXML =
         "<article><math>2x \\times 4y \\div 6z + 8 - \\frac {y}{z^2} = 0</math></article>";
 
-    testTranslation(stringWithCharacterReference, characterReferenceXML);
+    testTranslation(stringWithMathBlock, mathBlockXML);
+  }
+
+  @Test
+  void uppercaseMathBlocksDoNotBreakParser() {
+    final String stringWithMathBlock =
+        "<MATH>2x \\times 4y \\div 6z + 8 - \\frac {y}{z^2} = 0</MATH>";
+    final String mathBlockXML =
+        "<article><MATH>2x \\times 4y \\div 6z + 8 - \\frac {y}{z^2} = 0</MATH></article>";
+
+    testTranslation(stringWithMathBlock, mathBlockXML);
   }
 }

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/LinkGrammarTest.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/LinkGrammarTest.java
@@ -147,6 +147,11 @@ class LinkGrammarTest extends WikitextBaseTest {
     final String bareURLNoWikiXML = "<article><nowiki>https://www.wikipedia.org</nowiki></article>";
     testTranslation(bareURLNoWiki, bareURLNoWikiXML);
 
+    final String bareURLNoWikiUppercase = "<NOWIKI>https://www.wikipedia.org</NOWIKI>";
+    final String bareURLNoWikiUppercaseXML =
+        "<article><NOWIKI>https://www.wikipedia.org</NOWIKI></article>";
+    testTranslation(bareURLNoWikiUppercase, bareURLNoWikiUppercaseXML);
+
     final String linkWithoutArrow =
         "<span class=\"plainlinks\">[https://www.wikipedia.org Wikipedia]</span>";
     final String linkWithoutArrowXML =


### PR DESCRIPTION
Unparsed blocks should not need to be lowercase:
- code
- nowiki
- syntaxhighlight
- math