### PR TITLE
Combine text in tree

### DIFF
--- a/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/ast/base/WikiTextParentNode.java
+++ b/lib/src/main/java/com/lucaskjaerozhang/wikitext_parser/ast/base/WikiTextParentNode.java
@@ -1,5 +1,7 @@
 package com.lucaskjaerozhang.wikitext_parser.ast.base;
 
+import com.lucaskjaerozhang.wikitext_parser.ast.sections.Text;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -19,7 +21,26 @@ public abstract class WikiTextParentNode extends WikiTextNode {
    * @param children The child nodes
    */
   protected WikiTextParentNode(List<WikiTextNode> children) {
-    this.children = children;
+    this.children = combineTextNodes(children);
+  }
+
+  private List<WikiTextNode> combineTextNodes(List<WikiTextNode> children) {
+    List<WikiTextNode> newList = new ArrayList<>(children.size());
+    for (int i = 0; i < children.size(); i++) {
+      // If we're in the last item, we don't want to go outside the array bounds.
+      WikiTextNode first = children.get(i);
+      if (i < children.size() - 1) {
+        WikiTextNode second = children.get(i + 1);
+        if (first instanceof Text a && second instanceof Text b) {
+          Text c = new Text(a.getContent().concat(b.getContent()));
+          newList.add(c);
+          i++;
+          continue;
+        }
+      }
+      newList.add(first);
+    }
+    return newList;
   }
 
   /**

--- a/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/layout/SectionsGrammarTest.java
+++ b/lib/src/test/java/com/lucaskjaerozhang/wikitext_parser/grammar/layout/SectionsGrammarTest.java
@@ -1,7 +1,12 @@
 package com.lucaskjaerozhang.wikitext_parser.grammar.layout;
 
+import com.lucaskjaerozhang.wikitext_parser.TestErrorListener;
 import com.lucaskjaerozhang.wikitext_parser.WikitextBaseTest;
+import com.lucaskjaerozhang.wikitext_parser.ast.base.WikiTextNode;
+import com.lucaskjaerozhang.wikitext_parser.ast.root.Article;
+import com.lucaskjaerozhang.wikitext_parser.ast.sections.Text;
 import com.lucaskjaerozhang.wikitext_parser.grammar.WikiTextLexer;
+import com.lucaskjaerozhang.wikitext_parser.parse.ParseTreeBuilder;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -35,7 +40,18 @@ class SectionsGrammarTest extends WikitextBaseTest {
 
     Assertions.assertEquals(1, getResultsFromXPATH(plainTextString, "//text").size());
 
-    testTranslation(plainTextString, "<article>This is just plain text</article>");
+    Article root =
+        (Article)
+            ParseTreeBuilder.visitTreeFromText(
+                plainTextString, List.of(new TestErrorListener()), true);
+    Assertions.assertEquals(
+        "<article>This is just plain text</article>",
+        com.lucaskjaerozhang.wikitext_parser.WikiTextParser.writeToString(root));
+
+    List<WikiTextNode> children = root.getChildren();
+    Assertions.assertEquals(2, children.size());
+    Text textNode = (Text) children.get(1);
+    Assertions.assertEquals("This is just plain text", textNode.getContent());
   }
 
   @Test


### PR DESCRIPTION
## Problem
Text is currently defined in grammar, meaning each space produces a new text node. This is fine for the XML case but pretty annoying to other use cases.

## Solution
Combine consecutive text nodes.