### PR TITLE
Resolve more citations template

### DIFF
--- a/common/src/main/java/com/lucaskjaerozhang/wikitext_parser/common/metadata/WikiConstants.java
+++ b/common/src/main/java/com/lucaskjaerozhang/wikitext_parser/common/metadata/WikiConstants.java
@@ -15,10 +15,15 @@ public class WikiConstants {
       "Failed to load constants file %s: %s";
   private static final Gson gson = new Gson();
 
+  private static final Set<String> BEHAVIOR_SWITCHES = readSetConstant("behavior_switches.json");
   private static final Set<String> LANGUAGE_CODES =
       readSetOfStringsConstantToLowercase("language_codes.json");
   private static final Map<String, String> NAMESPACES = readMapConstant("namespaces.json");
   private static final Set<String> WIKIS = readSetOfStringsConstantToLowercase("wikis.json");
+
+  public static boolean isBehaviorSwitch(String behaviorSwitch) {
+    return BEHAVIOR_SWITCHES.contains(behaviorSwitch);
+  }
 
   public static boolean isLanguageCode(String languageCode) {
     return LANGUAGE_CODES.contains(languageCode.toLowerCase(Locale.ROOT));

--- a/common/src/main/resources/constants/behavior_switches.json
+++ b/common/src/main/resources/constants/behavior_switches.json
@@ -1,0 +1,23 @@
+[
+    "__NOTOC__",
+    "__FORCETOC__",
+    "__TOC__",
+    "__NOEDITSECTION__",
+    "__NEWSECTIONLINK__",
+    "__NONEWSECTIONLINK__",
+    "__NOGALLERY__",
+    "__HIDDENCAT__",
+    "__EXPECTUNUSEDCATEGORY__",
+    "__NOCONTENTCONVERT__",
+    "__NOCC__",
+    "__NOTITLECONVERT__",
+    "__NOTC__",
+    "__START__",
+    "__END__",
+    "__INDEX__",
+    "__NOINDEX__",
+    "__STATICREDIRECT__",
+    "__NOGLOBAL__",
+    "__DISAMBIG__",
+    "__EXPECTED_UNCONNECTED_PAGE__"
+]

--- a/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
+++ b/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
@@ -97,8 +97,8 @@ behaviorSwitch
    ;
 
 parserFunction
-   : OPEN_CURLY_BRACE OPEN_CURLY_BRACE ('safesubst' COLON)? parserFunctionName COLON ('safesubst' COLON)? parserFunctionParameter (PIPE parserFunctionParameter)* CLOSE_CURLY_BRACE CLOSE_CURLY_BRACE # RegularParserFunction
-   | OPEN_CURLY_BRACE OPEN_CURLY_BRACE ('safesubst' COLON)? parserFunctionName COLON ('safesubst' COLON)? (PIPE parserFunctionParameter)* CLOSE_CURLY_BRACE CLOSE_CURLY_BRACE # ParserFunctionWithBlankFirstParameter
+   : OPEN_CURLY_BRACE OPEN_CURLY_BRACE substitutionModifier? parserFunctionName COLON substitutionModifier? parserFunctionParameter (PIPE parserFunctionParameter)* CLOSE_CURLY_BRACE CLOSE_CURLY_BRACE # RegularParserFunction
+   | OPEN_CURLY_BRACE OPEN_CURLY_BRACE substitutionModifier? parserFunctionName COLON substitutionModifier? (PIPE parserFunctionParameter)* CLOSE_CURLY_BRACE CLOSE_CURLY_BRACE # ParserFunctionWithBlankFirstParameter
    ;
 
 parserFunctionName
@@ -112,6 +112,11 @@ parserFunctionCharacters
    | EQUALS
    | HASH
    | TEXT
+   ;
+
+substitutionModifier
+   : 'safesubst' COLON (OPEN_CARAT 'noinclude' SPACE* SLASH? CLOSE_CARAT)?
+   | 'SAFESUBST' COLON (OPEN_CARAT 'noinclude' SPACE* SLASH? CLOSE_CARAT)?
    ;
 
 parserFunctionParameter
@@ -143,6 +148,7 @@ parserFunctionParameterValues
    | unresolvedTemplateParameter
    | parserFunction
    | template
+   | behaviorSwitch
    ;
 
 any

--- a/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
+++ b/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
@@ -9,6 +9,7 @@ elements
    | unresolvedTemplateParameter
    | template
    | preprocessorDirective
+   | any
    ;
 
 nowikiBlock
@@ -106,6 +107,7 @@ parserFunctionName
 
 parserFunctionCharacters
    : ANY
+   | DOLLAR_SIGN
    | DASH
    | EXCLAMATION_MARK
    | EQUALS
@@ -127,6 +129,7 @@ parserFunctionParameter
 parserFunctionParameterValues
    : link
    | TEXT
+   | DOLLAR_SIGN
    | DASH
    | HASH
    | COLON
@@ -194,6 +197,10 @@ COMMA
 
 DASH
    : '-'
+   ;
+
+DOLLAR_SIGN
+   : '$'
    ;
 
 DOUBLE_QUOTE

--- a/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
+++ b/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
@@ -32,14 +32,15 @@ templateName
    ;
 
 templateParameter
-   : PIPE templateParameterKeyValues+ # UnnamedParameter
-   | PIPE templateParameterKeyValues+ EQUALS templateParameterParameterValues+ # NamedParameter
+   : PIPE templateParameterKeyValues* # UnnamedParameter
+   | PIPE templateParameterKeyValues+ EQUALS templateParameterParameterValues* # NamedParameter
    ;
 
 templateParameterKeyValues
    : link
    | template
    | parserFunction
+   | unresolvedTemplateParameter
    | SPACE
    | DOUBLE_QUOTE
    | SINGLE_QUOTE

--- a/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
+++ b/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
@@ -84,6 +84,7 @@ linkNamespaceComponent
 linkTarget
    : TEXT
    | DASH
+   | PERIOD
    ;
 
 preprocessorDirective

--- a/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
+++ b/preprocessor/src/main/antlr/com/lucaskjaerozhang/wikitext_parser/grammar/preprocess/WikiTextPreprocessor.g4
@@ -9,7 +9,6 @@ elements
    | unresolvedTemplateParameter
    | template
    | preprocessorDirective
-   | any
    ;
 
 nowikiBlock
@@ -115,8 +114,10 @@ parserFunctionCharacters
    ;
 
 substitutionModifier
-   : 'safesubst' COLON (OPEN_CARAT 'noinclude' SPACE* SLASH? CLOSE_CARAT)?
-   | 'SAFESUBST' COLON (OPEN_CARAT 'noinclude' SPACE* SLASH? CLOSE_CARAT)?
+   : 'safesubst' COLON (OPEN_CARAT 'noinclude' SLASH? CLOSE_CARAT)?
+   | 'SAFESUBST' COLON (OPEN_CARAT 'noinclude' SLASH? CLOSE_CARAT)?
+   | 'safesubst' COLON (OPEN_CARAT 'noinclude ' SLASH? CLOSE_CARAT)?
+   | 'SAFESUBST' COLON (OPEN_CARAT 'noinclude ' SLASH? CLOSE_CARAT)?
    ;
 
 parserFunctionParameter

--- a/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/Preprocessor.java
+++ b/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/Preprocessor.java
@@ -77,7 +77,7 @@ public class Preprocessor extends WikiTextPreprocessorBaseVisitor<String> {
         ctx.templateName().stream()
             .map(RuleContext::getText)
             .collect(Collectors.joining(""))
-            .trim();
+            .strip();
     Optional<String> processorVariable =
         Optional.ofNullable(variables.getOrDefault(templateName, null));
     return processorVariable.isEmpty()
@@ -93,7 +93,7 @@ public class Preprocessor extends WikiTextPreprocessorBaseVisitor<String> {
         ctx.templateName().stream()
             .map(RuleContext::getText)
             .collect(Collectors.joining(""))
-            .trim();
+            .strip();
     List<String> params = ctx.templateParameter().stream().map(this::visit).toList();
     Map<Boolean, List<String>> parameters =
         params.stream()
@@ -119,7 +119,7 @@ public class Preprocessor extends WikiTextPreprocessorBaseVisitor<String> {
         ctx.templateParameterKeyValues().stream()
             .map(RuleContext::getText)
             .collect(Collectors.joining())
-            .trim();
+            .strip();
     return String.format("%s%s", POSITIONAL_PARAMETER_PREFIX, positionalParameter);
   }
 
@@ -131,11 +131,11 @@ public class Preprocessor extends WikiTextPreprocessorBaseVisitor<String> {
         ctx.templateParameterKeyValues().stream()
             .map(RuleContext::getText)
             .collect(Collectors.joining())
-            .trim(),
+            .strip(),
         ctx.templateParameterParameterValues().stream()
             .map(RuleContext::getText)
             .collect(Collectors.joining())
-            .trim());
+            .strip());
   }
 
   @Override
@@ -154,12 +154,12 @@ public class Preprocessor extends WikiTextPreprocessorBaseVisitor<String> {
   @Override
   public String visitParserFunctionWithBlankFirstParameter(
       WikiTextPreprocessorParser.ParserFunctionWithBlankFirstParameterContext ctx) {
-    String parserFunctionName = ctx.parserFunctionName().getText().trim();
+    String parserFunctionName = ctx.parserFunctionName().getText().strip();
     List<Callable<String>> parameters =
         Stream.concat(
                 Stream.of(() -> ""),
                 ctx.parserFunctionParameter().stream()
-                    .map(p -> (Callable<String>) () -> visit(p).trim()))
+                    .map(p -> (Callable<String>) () -> visit(p).strip()))
             .toList();
 
     // Gets an Optional representing whether we implemented the function.
@@ -171,11 +171,11 @@ public class Preprocessor extends WikiTextPreprocessorBaseVisitor<String> {
   @Override
   public String visitRegularParserFunction(
       WikiTextPreprocessorParser.RegularParserFunctionContext ctx) {
-    String parserFunctionName = ctx.parserFunctionName().getText().trim();
+    String parserFunctionName = ctx.parserFunctionName().getText().strip();
 
     List<Callable<String>> parameters =
         ctx.parserFunctionParameter().stream()
-            .map(p -> (Callable<String>) () -> visit(p).trim())
+            .map(p -> (Callable<String>) () -> visit(p).strip())
             .toList();
 
     // Gets an Optional representing whether we implemented the function.

--- a/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/Preprocessor.java
+++ b/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/Preprocessor.java
@@ -97,6 +97,7 @@ public class Preprocessor extends WikiTextPreprocessorBaseVisitor<String> {
     List<String> params = ctx.templateParameter().stream().map(this::visit).toList();
     Map<Boolean, List<String>> parameters =
         params.stream()
+            .map(p -> Optional.of(p).orElse(""))
             .collect(Collectors.partitioningBy(p -> p.startsWith(NAMED_PARAMETER_PREFIX)));
     Map<String, String> namedParameters =
         parameters.get(true).stream()

--- a/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/Preprocessor.java
+++ b/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/Preprocessor.java
@@ -1,5 +1,6 @@
 package com.lucaskjaerozhang.wikitext_parser.preprocess;
 
+import com.lucaskjaerozhang.wikitext_parser.common.metadata.WikiConstants;
 import com.lucaskjaerozhang.wikitext_parser.grammar.preprocess.WikiTextPreprocessorBaseVisitor;
 import com.lucaskjaerozhang.wikitext_parser.grammar.preprocess.WikiTextPreprocessorLexer;
 import com.lucaskjaerozhang.wikitext_parser.grammar.preprocess.WikiTextPreprocessorParser;
@@ -136,14 +137,17 @@ public class Preprocessor extends WikiTextPreprocessorBaseVisitor<String> {
             .trim());
   }
 
-  /*
-   * We don't output the behavior switches, but we do want to get them.
-   */
   @Override
   public String visitBehaviorSwitch(WikiTextPreprocessorParser.BehaviorSwitchContext ctx) {
     String switchName = ctx.getText();
-    behaviorSwitches.add(switchName);
-    return "";
+    if (WikiConstants.isBehaviorSwitch(switchName)) {
+      // We don't output the behavior switches, but we do want to get them.
+      behaviorSwitches.add(switchName);
+      return "";
+    }
+
+    // Not a behavior switch? Leave it alone.
+    return switchName;
   }
 
   @Override

--- a/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/template/TemplateProcessor.java
+++ b/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/template/TemplateProcessor.java
@@ -55,10 +55,10 @@ public class TemplateProcessor {
                     () ->
                         new IllegalStateException(
                             String.format("Unable to resolve template %s", templateName))));
+
+    // This always needs to happen to deal with default parameters
     String substituted =
-        (positionalParameters.isEmpty() && namedParameters.isEmpty())
-            ? template
-            : substituter.evaluateTemplate(template, positionalParameters, namedParameters);
+        substituter.evaluateTemplate(template, positionalParameters, namedParameters);
 
     Preprocessor preprocessor =
         Preprocessor.builder()

--- a/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/template/TemplateProcessor.java
+++ b/preprocessor/src/main/java/com/lucaskjaerozhang/wikitext_parser/preprocess/template/TemplateProcessor.java
@@ -73,7 +73,9 @@ public class TemplateProcessor {
                     "NAMESPACEE",
                     "Template",
                     "TALKPAGENAME",
-                    "TALKPAGENAME"))
+                    "TALKPAGENAME",
+                    "NAMESPACENUMBER",
+                    "0"))
             .calledBy(visited)
             .templateProvider(provider)
             .templateProcessor(this)

--- a/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
+++ b/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
@@ -112,10 +112,20 @@ class MoratoriumTest extends PreprocessorEndToEndTest {
   /** More citations needed. */
   @Test
   void moreCitationsOnly() {
+    testPreprocessorWithFile("{{more citations needed|date=April 2009}}", "more_citations_needed");
+  }
+
+  @Test
+  void ambox() {
     testPreprocessorWithString(
         "{{Ambox\n| image = [[File:Question book-new.svg|50x40px|alt=]]\n}}",
         "<module name='Message box'><argument>ambox</argument></module>");
-    testPreprocessorWithFile("{{more citations needed|date=April 2009}}", "more_citations_needed");
+  }
+
+  @Test
+  void safesubstInvoke() {
+    testPreprocessorWithString(
+        "{{SAFESUBST:<noinclude />#invoke:Unsubst||date=__DATE__ |$B=\nambox\n}}", "");
   }
 
   @Test

--- a/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
+++ b/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
@@ -115,6 +115,16 @@ class MoratoriumTest extends PreprocessorEndToEndTest {
     testPreprocessorWithFile("{{more citations needed|date=April 2009}}", "more_citations_needed");
   }
 
+  /*
+   * Reflist
+   */
+
+  /** Main reflist test */
+  @Test
+  void reflist() {
+    testPreprocessorWithFile("{{Reflist}}", "reflist.txt");
+  }
+
   @Test
   void ambox() {
     testPreprocessorWithString(

--- a/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
+++ b/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
@@ -125,6 +125,9 @@ class MoratoriumTest extends PreprocessorEndToEndTest {
   @Test
   void safesubstInvoke() {
     testPreprocessorWithString(
+        "{{SAFESUBST:<noinclude />#invoke:Unsubst|}}",
+        "<module name='Unsubst'><argument></argument></module>");
+    testPreprocessorWithString(
         "{{SAFESUBST:<noinclude />#invoke:Unsubst||date=__DATE__ |$B=\nambox\n}}", "");
   }
 

--- a/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
+++ b/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
@@ -128,7 +128,8 @@ class MoratoriumTest extends PreprocessorEndToEndTest {
         "{{SAFESUBST:<noinclude />#invoke:Unsubst|}}",
         "<module name='Unsubst'><argument></argument></module>");
     testPreprocessorWithString(
-        "{{SAFESUBST:<noinclude />#invoke:Unsubst||date=__DATE__ |$B=\nambox\n}}", "");
+        "{{SAFESUBST:<noinclude />#invoke:Unsubst||date=__DATE__ |$B=\nambox\n}}",
+        "<module name='Unsubst'><argument></argument><argument>date=__DATE__</argument><argument>$B=\nambox</argument></module>");
   }
 
   @Test

--- a/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
+++ b/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
@@ -110,19 +110,15 @@ class MoratoriumTest extends PreprocessorEndToEndTest {
   }
 
   /** More citations needed. */
-  //  @Test
-  //  void moreCitationsOnly() {
-  //    testPreprocessorWithFile("{{more citations needed|date=April 2009}}",
-  // "more_citations_needed");
-  //  }
-  //
-  //  @Test
-  //  void moreCitationsFix() {
-  //    testPreprocessorWithString(
-  //        "{{#if:{{{unquoted|}}}| <br /><small>{{find sources
-  // mainspace|.|{{{unquoted|}}}}}</small> |{{#if:|{{#ifeq:  |none ||<br /><small>{{find sources
-  // mainspace|{{{find}}} }}</small>}}|<br /><small><module name='Find sources'><argument>Find
-  // sources mainspace</argument></module></small>}} }}",
-  //        "");
-  //  }
+  @Test
+  void moreCitationsOnly() {
+    testPreprocessorWithFile("{{more citations needed|date=April 2009}}", "more_citations_needed");
+  }
+
+  @Test
+  void moreCitationsFix() {
+    testPreprocessorWithString(
+        "{{#if:| <br /><small>{{find sources mainspace|.|}}</small> |{{#if:|{{#ifeq:  |none ||<br /><small>{{find sources mainspace|{{{find}}} }}</small>}}|<br /><small><module name='Find sources'><argument>Find sources mainspace</argument></module></small>}} }}",
+        "<br /><small><module name='Find sources'><argument>Find sources mainspace</argument></module></small>");
+  }
 }

--- a/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
+++ b/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
@@ -112,6 +112,9 @@ class MoratoriumTest extends PreprocessorEndToEndTest {
   /** More citations needed. */
   @Test
   void moreCitationsOnly() {
+    testPreprocessorWithString(
+        "{{Ambox\n| image = [[File:Question book-new.svg|50x40px|alt=]]\n}}",
+        "<module name='Message box'><argument>ambox</argument></module>");
     testPreprocessorWithFile("{{more citations needed|date=April 2009}}", "more_citations_needed");
   }
 

--- a/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
+++ b/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/MoratoriumTest.java
@@ -122,7 +122,14 @@ class MoratoriumTest extends PreprocessorEndToEndTest {
   /** Main reflist test */
   @Test
   void reflist() {
-    testPreprocessorWithFile("{{Reflist}}", "reflist.txt");
+    testPreprocessorWithFile("{{Reflist}}", "reflist");
+  }
+
+  @Test
+  void reflistSwitch() {
+    testPreprocessorWithString(
+        "{{#switch:|upper-alpha|upper-roman|lower-alpha|lower-greek|lower-roman=reflist-{{{group}}}}}",
+        "reflist-{{{group}}}");
   }
 
   @Test

--- a/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/PreprocessorEndToEndTest.java
+++ b/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/e2e/PreprocessorEndToEndTest.java
@@ -35,7 +35,15 @@ abstract class PreprocessorEndToEndTest {
     preprocessor =
         Preprocessor.builder()
             .variables(
-                Map.of("PAGENAME", "Moratorium", "NAMESPACE", "Template", "NAMESPACEE", "Template"))
+                Map.of(
+                    "PAGENAME",
+                    "Moratorium",
+                    "NAMESPACE",
+                    "Template",
+                    "NAMESPACEE",
+                    "Template",
+                    "NAMESPACENUMBER",
+                    "0"))
             .templateProvider(new OnlineTemplateProvider(testClient))
             .build();
   }

--- a/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/template/TemplateParameterSubstituterTest.java
+++ b/preprocessor/src/test/java/com/lucaskjaerozhang/wikitext_parser/preprocess/template/TemplateParameterSubstituterTest.java
@@ -37,4 +37,13 @@ class TemplateParameterSubstituterTest {
             hoverTitle, List.of("title", "second"), Map.of("dotted", "true", "link", "link"));
     Assertions.assertEquals(expected, result);
   }
+
+  @Test
+  void templateEvaluatorCanSubstituteNestedVariables() {
+    final String input = "{{{liststyle|{{{group|}}}}}}";
+    final String expected = "";
+    TemplateParameterSubstituter evaluator = new TemplateParameterSubstituter();
+    String result = evaluator.evaluateTemplate(input, List.of(), Map.of());
+    Assertions.assertEquals(expected, result);
+  }
 }

--- a/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/Moratorium_(law).txt
+++ b/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/Moratorium_(law).txt
@@ -5,7 +5,7 @@ A '''moratorium''' is a delay or suspension of an activity or a law. In a [[lega
 
 For example, [[animal rights]] activists and [[Conservation movement|conservation]] authorities may request fishing or hunting moratoria to protect [[endangered]] or threatened animal species.  These delays, or suspensions, prevent people from hunting or fishing the animals in discussion.
 
-Another instance is a delay of legal obligations or payment (''[[debt moratorium]]''). A legal official can order {{ safesubst:<noinclude/>#invoke:Unsubst||date= |$B=
+Another instance is a delay of legal obligations or payment (''[[debt moratorium]]''). A legal official can order {{ safesubst:<noinclude/>#invoke:Unsubst||date=__DATE__ |$B=
 <span class="cleanup-needed-content" style="padding-left:0.1em; padding-right:0.1em; color:#595959; border:1px solid #DDD;">a delay of payment</span>{{#switch:¬
  |¬=<module name='Category handler'><argument>main</argument></module>
  |SUBST=[[Category:Pages with incorrectly substituted templates]]
@@ -13,11 +13,7 @@ Another instance is a delay of legal obligations or payment (''[[debt moratorium
  |
  |<sup class="noprint Inline-Template " style="margin-left:0.1em; white-space:nowrap;">&#91;<i>{{#if:
   |&#32;
- }}[[Wikipedia:Cleanup|<span title="{{replace|{{{#invoke:Error|error|{{{mbox
-| image = none
-| style = background-color: LightBlue;border: 1px solid RoyalBlue;font-weight: bold;margin: 0em 0 1em;padding: .5em 1em;text-align: center;
-| text = Please leave a <span style="color: #5a3696;"><span class="noprint plainlinks" title="Edit TALKPAGENAME">[{{fullurl:TALKPAGENAME|action=edit{{#if:new|&section=new}}{{#if:|&editintro=%7B%7B%7Beditintro%7D%7D%7D}}{{#if:|&preload=%7B%7B%7Bpreload%7D%7D%7D}}{{#if:|&preloadtitle=%7B%7B%7Bpreloadtitle%7D%7D%7D}}}} edit]</span></span>{{safesubst:#if:|&nbsp;or [{{fullurl:Special:Emailuser/{{PAGENAMEE}}}} <span style="color: #5a3696;">e-mail me</span>]}}.
-}}}|tag=}}}|"|&quot;}}{{#if:December 2015|<nowiki/> (December 2015)}}">clarification needed</span>]]{{#if:
+ }}[[Wikipedia:Cleanup|<span title="{{replace|Wikipedia:Cleanup|"|&quot;}}{{#if:December 2015|<nowiki/> (December 2015)}}">clarification needed</span>]]{{#if:
   |&#32;
  }}</i>&#93;</sup>
 }}
@@ -27,7 +23,7 @@ Another instance is a delay of legal obligations or payment (''[[debt moratorium
 {{Sister project
 |position=
 |project=wiktionary
-|text=Look up '''''[[wiktionary:Special:Search/{{safesubst:subpagename:{{{1|}}}}}[[category:pages which use a template in place of a magic word|k{{pagename}}]]|{{safesubst:subpagename:{{{1|}}}}}[[category:pages which use a template in place of a magic word|k{{pagename}}]]]]'''''{{#if:
+|text=Look up '''''[[wiktionary:Special:Search/{{safesubst:subpagename:}}[[category:pages which use a template in place of a magic word|k{{pagename}}]]|{{safesubst:subpagename:}}[[category:pages which use a template in place of a magic word|k{{pagename}}]]]]'''''{{#if:
   |{{#if:
    |,
    |&nbsp;or
@@ -40,9 +36,9 @@ Another instance is a delay of legal obligations or payment (''[[debt moratorium
 *[[UN moratorium on the death penalty]]
 
 ==References==
-<templatestyles src="Reflist/styles.css" /><div class="reflist reflist-columns references-column-width {{#switch:{{{liststyle|{{{group|}}}}}}|upper-alpha|upper-roman|lower-alpha|lower-greek|lower-roman=reflist-{{{liststyle|{{{group}}}}}}}} " style="column-width: {{{1}}};">
-<references group='{{{group|}}}' responsive='0'>{{{refs|}}}</references></div><module name='Check for unknown parameters'><argument>check</argument><argument>unknown=</argument><argument>preview=Page using [[Template:Reflist]] with unknown parameter "_VALUE_"</argument><argument>ignoreblank=y</argument><argument>1</argument><argument>colwidth</argument><argument>group</argument><argument>liststyle</argument><argument>refs</argument></module>
-*{{#if:{{{noicon|}}}||{{#if:|[[Image:PD-icon.svg|wikisource-logo.svg|12px|link=]]&nbsp;}}}}{{#if:|This article incorporates text from a publication now in the [[public domain]]:&nbsp;|}}<module name='template wrapper'><argument>wrap</argument><argument>_template=cite encyclopedia</argument><argument>_exclude=display, inline, no-icon, noicon, short, supplement, wstitle, vb, _debug</argument><argument>_reuse=title</argument><argument>year=1905</argument><argument>encyclopedia = [[New International Encyclopedia]]</argument><argument>title=</argument><argument>url=</argument><argument>edition=1st</argument><argument>location=New York</argument><argument>publisher=Dodd, Mead</argument><argument>editor-first=D. C.</argument><argument>editor-last=Gilman</argument><argument>editor-link=Daniel Coit Gilman</argument><argument>editor2-first=H. T.</argument><argument>editor2-last=Peck</argument><argument>editor3-first=F. M.</argument><argument>editor3-last=Colby</argument></module>
+<templatestyles src="Reflist/styles.css" /><div class="reflist  reflist-{{{group}}} " >
+<references group='' responsive='1'></references></div><module name='Check for unknown parameters'><argument>check</argument><argument>unknown=</argument><argument>preview=Page using [[Template:Reflist]] with unknown parameter "_VALUE_"</argument><argument>ignoreblank=y</argument><argument>1</argument><argument>colwidth</argument><argument>group</argument><argument>liststyle</argument><argument>refs</argument></module>
+*}}
 
 <module name='Authority control'><argument>authorityControl</argument></module>Category=<module name='Check for unknown parameters'><argument>check</argument><argument>arts</argument><argument>state</argument><argument>extralist</argument><argument>ignoreblank=1</argument><argument>showblankpositional=1</argument><argument>unknown=[[Category:Pages using authority control with parameters|_VALUE_]]|preview=Page using [[Template:Authority control]] with "_VALUE_", please move this to Wikidata if possible</argument></module>
 

--- a/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/Moratorium_(law).txt
+++ b/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/Moratorium_(law).txt
@@ -1,20 +1,6 @@
 <div class="shortdescription nomobile noexcerpt noprint searchaux" style="display:none">Delay or suspension of an activity or a law{{SHORTDESC:Delay or suspension of an activity or a law|}}</div>[[Category:<module name='pagetype'><argument>main</argument></module> with short description]]<module name='Check for unknown parameters'><argument>check</argument><argument>unknown=</argument><argument>preview=Page using [[Template:Short description]] with unknown parameter "_VALUE_"</argument><argument>ignoreblank=y</argument><argument>1</argument><argument>2</argument><argument>pagetype</argument><argument>bot</argument><argument>plural</argument></module><ifexpr><conditional><module name='String'><argument>len</argument><argument>Delay or suspension of an activity or a law</argument></module>>100</conditional><ifTrue>[[Category:<module name='pagetype'><argument>main</argument></module> with long short description]]</ifTrue><ifFalse></ifFalse></ifexpr>
-{{SAFESUBST:<noinclude />#invoke:Unsubst||date= |$B=
-{{Ambox
-| name  = More citations needed
-| small = 
-| type  = content
-| class = ambox-Refimprove
-| image = [[File:Question book-new.svg|50x40px|alt=]]
-| issue = This article '''needs additional citations for [[Wikipedia:Verifiability|verification]]'''.
-| fix   = Please help [{{fullurl:{{FULLPAGENAME}}|action=edit}} improve this article] by [[Help:Referencing for beginners|adding citations to reliable sources]]. Unsourced material may be challenged and removed.{{#if:{{{unquoted|}}}| <br /><small>{{find sources mainspace|.|{{{unquoted|}}}}}</small> |{{#if:|{{#ifeq:  |none ||<br /><small>{{find sources mainspace|{{{find}}} }}</small>}}|<br /><small><module name='Find sources'><argument>Find sources mainspace</argument></module></small>}} }}
-| removalnotice = yes
-| talk  = 
-| date  = April 2009
-| cat   = Articles needing additional references
-| all   = All articles needing additional references
-}}
-}}
+<module name='Unsubst'><argument></argument><argument>date=__DATE__</argument><argument>$B=
+<module name='Message box'><argument>ambox</argument></module></argument></module>
 A '''moratorium''' is a delay or suspension of an activity or a law. In a [[legal]] context, it may refer to the temporary suspension of a law to allow a legal challenge to be carried out.
 
 For example, [[animal rights]] activists and [[Conservation movement|conservation]] authorities may request fishing or hunting moratoria to protect [[endangered]] or threatened animal species.  These delays, or suspensions, prevent people from hunting or fishing the animals in discussion.

--- a/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/more_citations_needed.txt
+++ b/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/more_citations_needed.txt
@@ -1,16 +1,3 @@
 {{SAFESUBST:<noinclude />#invoke:Unsubst||date=__DATE__ |$B=
-{{Ambox
-| name  = More citations needed
-| small = 
-| type  = content
-| class = ambox-Refimprove
-| image = [[File:Question book-new.svg|50x40px|alt=]]
-| issue = This article '''needs additional citations for [[Wikipedia:Verifiability|verification]]'''.
-| fix   = Please help [{{fullurl:{{FULLPAGENAME}}|action=edit}} improve this article] by [[Help:Referencing for beginners|adding citations to reliable sources]]. Unsourced material may be challenged and removed.<br /><small><module name='Find sources'><argument>Find sources mainspace</argument></module></small>
-| removalnotice = yes
-| talk  = 
-| date  = April 2009
-| cat   = Articles needing additional references
-| all   = All articles needing additional references
-}}
+<module name='Message box'><argument>ambox</argument></module>
 }}

--- a/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/more_citations_needed.txt
+++ b/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/more_citations_needed.txt
@@ -6,7 +6,7 @@
 | class = ambox-Refimprove
 | image = [[File:Question book-new.svg|50x40px|alt=]]
 | issue = This article '''needs additional citations for [[Wikipedia:Verifiability|verification]]'''.
-| fix   = Please help [{{fullurl:{{FULLPAGENAME}}|action=edit}} improve this article] by [[Help:Referencing for beginners|adding citations to reliable sources]]. Unsourced material may be challenged and removed.
+| fix   = Please help [{{fullurl:{{FULLPAGENAME}}|action=edit}} improve this article] by [[Help:Referencing for beginners|adding citations to reliable sources]]. Unsourced material may be challenged and removed.<br /><small><module name='Find sources'><argument>Find sources mainspace</argument></module></small>
 | removalnotice = yes
 | talk  = 
 | date  = April 2009

--- a/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/more_citations_needed.txt
+++ b/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/more_citations_needed.txt
@@ -14,4 +14,3 @@
 | all   = All articles needing additional references
 }}
 }}
-{{#if:{{{unquoted|}}}| <br /><small>{{find sources mainspace|.|{{{unquoted|}}}}}</small> |{{#if:|{{#ifeq:  |none ||<br /><small>{{find sources mainspace|{{{find}}} }}</small>}}|<br /><small><module name='Find sources'><argument>Find sources mainspace</argument></module></small>}} }}

--- a/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/more_citations_needed.txt
+++ b/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/more_citations_needed.txt
@@ -1,3 +1,2 @@
-{{SAFESUBST:<noinclude />#invoke:Unsubst||date=__DATE__ |$B=
-<module name='Message box'><argument>ambox</argument></module>
-}}
+<module name='Unsubst'><argument></argument><argument>date=__DATE__</argument><argument>$B=
+<module name='Message box'><argument>ambox</argument></module></argument></module>

--- a/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/reflist.txt
+++ b/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/reflist.txt
@@ -1,9 +1,2 @@
-<templatestyles src="Reflist/styles.css" /><div class="reflist <!--
--->{{#if:{{{1|}}}{{{colwidth|}}}|reflist-columns references-column-width}} <!--
--->{{#switch:{{{liststyle|{{{group|}}}}}}|upper-alpha|upper-roman|lower-alpha|lower-greek|lower-roman=reflist-{{{liststyle|{{{group}}}}}}}} <!--
--->{{#if:{{{1|}}}|{{#iferror:{{#ifexpr: {{{1|1}}} > 1 }}||{{#switch:{{{1|}}}|1=|2=reflist-columns-2|#default=reflist-columns-3}} }}}}" <!-- end class
--->{{#if: {{{1|}}}<!-- start style -->
-    | {{#iferror: {{#ifexpr: {{{1|1}}} > 1 }} |style="column-width: {{{1}}};"}}
-    | {{#if: {{{colwidth|}}}|style="column-width: {{{colwidth}}};"}}
-    }}>
-{{#tag:references|{{{refs|}}}|group={{{group|}}}|responsive={{#if:{{{1|}}}{{{colwidth|}}}|0|1}}}}</div>{{#invoke:Check for unknown parameters|check|unknown={{main other|[[Category:Pages using reflist with unknown parameters|_VALUE_{{PAGENAME}}]]}}|preview=Page using [[Template:Reflist]] with unknown parameter "_VALUE_"|ignoreblank=y| 1 | colwidth | group | liststyle | refs }}
+<templatestyles src="Reflist/styles.css" /><div class="reflist  reflist-{{{group}}} " >
+<references group='' responsive='1'></references></div><module name='Check for unknown parameters'><argument>check</argument><argument>unknown=</argument><argument>preview=Page using [[Template:Reflist]] with unknown parameter "_VALUE_"</argument><argument>ignoreblank=y</argument><argument>1</argument><argument>colwidth</argument><argument>group</argument><argument>liststyle</argument><argument>refs</argument></module>

--- a/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/reflist.txt
+++ b/preprocessor/src/test/resources/e2e/wikipedia/en/Moratorium_(law)/reflist.txt
@@ -1,0 +1,9 @@
+<templatestyles src="Reflist/styles.css" /><div class="reflist <!--
+-->{{#if:{{{1|}}}{{{colwidth|}}}|reflist-columns references-column-width}} <!--
+-->{{#switch:{{{liststyle|{{{group|}}}}}}|upper-alpha|upper-roman|lower-alpha|lower-greek|lower-roman=reflist-{{{liststyle|{{{group}}}}}}}} <!--
+-->{{#if:{{{1|}}}|{{#iferror:{{#ifexpr: {{{1|1}}} > 1 }}||{{#switch:{{{1|}}}|1=|2=reflist-columns-2|#default=reflist-columns-3}} }}}}" <!-- end class
+-->{{#if: {{{1|}}}<!-- start style -->
+    | {{#iferror: {{#ifexpr: {{{1|1}}} > 1 }} |style="column-width: {{{1}}};"}}
+    | {{#if: {{{colwidth|}}}|style="column-width: {{{colwidth}}};"}}
+    }}>
+{{#tag:references|{{{refs|}}}|group={{{group|}}}|responsive={{#if:{{{1|}}}{{{colwidth|}}}|0|1}}}}</div>{{#invoke:Check for unknown parameters|check|unknown={{main other|[[Category:Pages using reflist with unknown parameters|_VALUE_{{PAGENAME}}]]}}|preview=Page using [[Template:Reflist]] with unknown parameter "_VALUE_"|ignoreblank=y| 1 | colwidth | group | liststyle | refs }}

--- a/preprocessor/src/test/resources/source/wikipedia/en/Template:Ambox.json
+++ b/preprocessor/src/test/resources/source/wikipedia/en/Template:Ambox.json
@@ -1,1 +1,15 @@
-{"id":13179742,"key":"Template:Ambox","title":"Template:Ambox","latest":{"id":1052357064,"timestamp":"2021-10-28T18:27:47Z"},"content_model":"wikitext","license":{"url":"https://creativecommons.org/licenses/by-sa/3.0/","title":"Creative Commons Attribution-Share Alike 3.0"},"source":"{{#invoke:Message box|ambox}}{{#ifeq:{{{small}}};{{NAMESPACENUMBER}}|left;0|[[Category:Articles using small message boxes]]}}\u003cnoinclude\u003e\n{{documentation}}\n\u003c!-- Categories go on the /doc subpage, and interwikis go on Wikidata. --\u003e\n\u003c/noinclude\u003e"}
+{
+    "content_model": "wikitext",
+    "license": {
+        "title": "Creative Commons Attribution-Share Alike 3.0",
+        "url": "https://creativecommons.org/licenses/by-sa/3.0/"
+    },
+    "id": 13179742,
+    "source": "{{#invoke:Message box|ambox}}{{#ifeq:{{{small}}};{{NAMESPACENUMBER}}|left;0|[[Category:Articles using small message boxes]]}}<noinclude>\n{{documentation}}\n<!-- Categories go on the /doc subpage, and interwikis go on Wikidata. -->\n<\/noinclude>",
+    "title": "Template:Ambox",
+    "key": "Template:Ambox",
+    "latest": {
+        "id": 1052357064,
+        "timestamp": "2021-10-28T18:27:47Z"
+    }
+}


### PR DESCRIPTION
Tracking down all the changes from `{{more citations needed|date=April 2009}}`.
Fixes include:
- Actually implementing behavioral switches instead of assuming everything of the form `__name__` matches.
- Template parameter placeholders can be nested.
- Template parameters can be blank
- Template parameters can contain `$`
- Parser function modifiers don't break parsing despite not being implemented.
- Use `String.strip()` over `String.trim()` since it is best practice to use that.